### PR TITLE
Add Renovate scheduled pipeline for dependency updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,9 @@ test:
 # RENOVATE=true. Voraussetzung: CI/CD-Variable RENOVATE_TOKEN (GitLab PAT mit
 # api-Scope, masked + protected). Manuelle Ausführung via "Run pipeline" mit
 # RENOVATE=true ebenfalls möglich.
+#
+# Network-Egress des Runners: siehe docs/REQUIREMENTS.md
+# (Abschnitt "Renovate-Pipeline: Netzwerk-Ziele").
 renovate:
   stage: renovate
   image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
-# GitLab CI - läuft Lint + Test auf jedem MR.
-stages: [lint, test]
+# GitLab CI - läuft Lint + Test auf jedem MR; Renovate via Scheduled Pipeline.
+stages: [lint, test, renovate]
 
 default:
   image: ghcr.io/astral-sh/uv:python3.12-bookworm
@@ -13,9 +13,40 @@ lint:
   script:
     - task dev:lint:sh
     - task dev:lint:py
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $RENOVATE == "true"
+      when: never
+    - when: on_success
 
 test:
   stage: test
   script:
     - task dev:test:bash
     - task dev:test:py
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $RENOVATE == "true"
+      when: never
+    - when: on_success
+
+# Renovate läuft als Scheduled Pipeline (CI/CD > Schedules) mit der Variable
+# RENOVATE=true. Voraussetzung: CI/CD-Variable RENOVATE_TOKEN (GitLab PAT mit
+# api-Scope, masked + protected). Manuelle Ausführung via "Run pipeline" mit
+# RENOVATE=true ebenfalls möglich.
+renovate:
+  stage: renovate
+  image:
+    name: renovate/renovate:latest
+    entrypoint: [""]
+  before_script: []
+  variables:
+    LOG_LEVEL: info
+    RENOVATE_PLATFORM: gitlab
+    RENOVATE_ENDPOINT: $CI_API_V4_URL
+    RENOVATE_AUTODISCOVER: "false"
+    RENOVATE_REPOSITORIES: '["$CI_PROJECT_PATH"]'
+    RENOVATE_GIT_AUTHOR: "Renovate Bot <renovate@$CI_SERVER_HOST>"
+  script:
+    - renovate
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $RENOVATE == "true"
+    - if: $CI_PIPELINE_SOURCE == "web" && $RENOVATE == "true"

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -41,3 +41,51 @@ Gibt eine Übersicht aus, was vorhanden / was fehlt.
 | `WIN_USER` / `WIN_PASSWORD` | WinRM | Domänen-Account mit Remoting |
 
 Trag die Werte in `.env` ein (lokal) bzw. in der CI als geschützte Variablen.
+
+## Renovate-Pipeline: Netzwerk-Ziele
+
+Der GitLab-Runner, auf dem der `renovate`-Job aus `.gitlab-ci.yml` läuft, steht
+typischerweise in einem abgeschotteten Netz. Folgende ausgehenden Verbindungen
+(HTTPS/443, sofern nicht anders vermerkt) müssen freigeschaltet bzw. über einen
+Proxy/Mirror erreichbar sein:
+
+### Pflicht (Runner-Infrastruktur)
+
+| Ziel | Zweck |
+|---|---|
+| `<dein-gitlab-host>` (`$CI_SERVER_URL`) | Repo klonen, MRs anlegen, Issues/Dashboard schreiben (via `RENOVATE_TOKEN`) |
+| Registry des Renovate-Images (Default `docker.io` → `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com`) | Pull von `renovate/renovate:latest` beim Job-Start |
+| `app.renovatebot.com` | Optional, aber Default: Merge-Confidence- und Release-Daten. Per `RENOVATE_MERGE_CONFIDENCE_ENDPOINT=""` deaktivierbar |
+
+Steht im abgeschotteten Netz eine eigene Registry zur Verfügung, das
+Renovate-Image dorthin spiegeln und im Job auf
+`<interne-registry>/renovate/renovate:<tag>` umstellen.
+
+### Pflicht (Dependency-Lookups, abhängig von Managern)
+
+Renovate fragt für jeden im Repo aktiven Manager den passenden Upstream ab.
+Aktuell relevant für dieses Repo:
+
+| Manager / Datei | Ziel | Zweck |
+|---|---|---|
+| `pep621` / `uv` (`pyproject.toml`, `uv.lock`) | `pypi.org`, `files.pythonhosted.org` | Python-Paket-Versionen + Metadaten |
+| `github-actions` (`.github/workflows/*.yml`) | `api.github.com`, `github.com`, `objects.githubusercontent.com`, `raw.githubusercontent.com` | Action-Tags, Commit-SHAs, Release-Notes |
+| `dockerfile` / `docker-compose` / `gitlabci` (z. B. `ghcr.io/astral-sh/uv`, `renovate/renovate`) | `ghcr.io` (+ `pkg-containers.githubusercontent.com`), `registry-1.docker.io`, `auth.docker.io` | Image-Tag-Listen, Manifeste |
+| `terraform` (`infrastructure/terraform/`) | `registry.terraform.io`, `releases.hashicorp.com`, ggf. `github.com` (Module per Git-Source) | Provider- und Modul-Versionen |
+| `ansible-galaxy` (`infrastructure/ansible/`, `requirements.yml`) | `galaxy.ansible.com` | Collection-/Role-Versionen |
+| Changelog-Fetching (alle Manager) | `api.github.com`, `gitlab.com/api/v4` | Release-Notes in MR-Bodies (per `RENOVATE_FETCH_CHANGE_LOGS=off` abschaltbar) |
+
+### GitHub-API-Token empfohlen
+
+Renovate fragt für Changelogs und Container-Tag-Lookups häufig `api.github.com`
+ab — ohne Auth greift dort das anonyme Rate-Limit von 60 req/h. CI/CD-Variable
+`GITHUB_COM_TOKEN` (Read-only PAT, Scope `public_repo` reicht) im Projekt
+setzen, dann nutzt Renovate ihn automatisch.
+
+### Proxy / Air-Gap
+
+- Standard-Proxy via `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` (Job- oder
+  Runner-ENV) — Renovate respektiert diese Variablen.
+- Für komplett air-gapped Umgebungen interne Mirrors für PyPI, Container-
+  Registry, Terraform-Registry und Ansible-Galaxy aufsetzen und Renovate per
+  `hostRules` (in `renovate.json`) auf diese Mirrors umbiegen.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -44,48 +44,15 @@ Trag die Werte in `.env` ein (lokal) bzw. in der CI als geschützte Variablen.
 
 ## Renovate-Pipeline: Netzwerk-Ziele
 
-Der GitLab-Runner, auf dem der `renovate`-Job aus `.gitlab-ci.yml` läuft, steht
-typischerweise in einem abgeschotteten Netz. Folgende ausgehenden Verbindungen
-(HTTPS/443, sofern nicht anders vermerkt) müssen freigeschaltet bzw. über einen
-Proxy/Mirror erreichbar sein:
+Egress (HTTPS/443), den der Runner für den `renovate`-Job erreichen muss:
 
-### Pflicht (Runner-Infrastruktur)
-
-| Ziel | Zweck |
+| Domain | Wofür |
 |---|---|
-| `<dein-gitlab-host>` (`$CI_SERVER_URL`) | Repo klonen, MRs anlegen, Issues/Dashboard schreiben (via `RENOVATE_TOKEN`) |
-| Registry des Renovate-Images (Default `docker.io` → `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com`) | Pull von `renovate/renovate:latest` beim Job-Start |
-| `app.renovatebot.com` | Optional, aber Default: Merge-Confidence- und Release-Daten. Per `RENOVATE_MERGE_CONFIDENCE_ENDPOINT=""` deaktivierbar |
-
-Steht im abgeschotteten Netz eine eigene Registry zur Verfügung, das
-Renovate-Image dorthin spiegeln und im Job auf
-`<interne-registry>/renovate/renovate:<tag>` umstellen.
-
-### Pflicht (Dependency-Lookups, abhängig von Managern)
-
-Renovate fragt für jeden im Repo aktiven Manager den passenden Upstream ab.
-Aktuell relevant für dieses Repo:
-
-| Manager / Datei | Ziel | Zweck |
-|---|---|---|
-| `pep621` / `uv` (`pyproject.toml`, `uv.lock`) | `pypi.org`, `files.pythonhosted.org` | Python-Paket-Versionen + Metadaten |
-| `github-actions` (`.github/workflows/*.yml`) | `api.github.com`, `github.com`, `objects.githubusercontent.com`, `raw.githubusercontent.com` | Action-Tags, Commit-SHAs, Release-Notes |
-| `dockerfile` / `docker-compose` / `gitlabci` (z. B. `ghcr.io/astral-sh/uv`, `renovate/renovate`) | `ghcr.io` (+ `pkg-containers.githubusercontent.com`), `registry-1.docker.io`, `auth.docker.io` | Image-Tag-Listen, Manifeste |
-| `terraform` (`infrastructure/terraform/`) | `registry.terraform.io`, `releases.hashicorp.com`, ggf. `github.com` (Module per Git-Source) | Provider- und Modul-Versionen |
-| `ansible-galaxy` (`infrastructure/ansible/`, `requirements.yml`) | `galaxy.ansible.com` | Collection-/Role-Versionen |
-| Changelog-Fetching (alle Manager) | `api.github.com`, `gitlab.com/api/v4` | Release-Notes in MR-Bodies (per `RENOVATE_FETCH_CHANGE_LOGS=off` abschaltbar) |
-
-### GitHub-API-Token empfohlen
-
-Renovate fragt für Changelogs und Container-Tag-Lookups häufig `api.github.com`
-ab — ohne Auth greift dort das anonyme Rate-Limit von 60 req/h. CI/CD-Variable
-`GITHUB_COM_TOKEN` (Read-only PAT, Scope `public_repo` reicht) im Projekt
-setzen, dann nutzt Renovate ihn automatisch.
-
-### Proxy / Air-Gap
-
-- Standard-Proxy via `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` (Job- oder
-  Runner-ENV) — Renovate respektiert diese Variablen.
-- Für komplett air-gapped Umgebungen interne Mirrors für PyPI, Container-
-  Registry, Terraform-Registry und Ansible-Galaxy aufsetzen und Renovate per
-  `hostRules` (in `renovate.json`) auf diese Mirrors umbiegen.
+| `<dein-gitlab-host>` (`$CI_SERVER_URL`) | Repo klonen, MRs/Issues schreiben |
+| `registry-1.docker.io`, `auth.docker.io` | Pull `renovate/renovate`-Image |
+| `app.renovatebot.com` | Merge-Confidence- / Release-Daten |
+| `pypi.org`, `files.pythonhosted.org` | Python-Deps (`pyproject.toml`, `uv.lock`) |
+| `api.github.com`, `github.com`, `objects.githubusercontent.com`, `raw.githubusercontent.com` | GitHub-Actions-Tags + Changelogs |
+| `ghcr.io`, `pkg-containers.githubusercontent.com` | Container-Images aus GHCR (z. B. `astral-sh/uv`) |
+| `registry.terraform.io`, `releases.hashicorp.com` | Terraform-Provider/-Module |
+| `galaxy.ansible.com` | Ansible-Collections/-Roles |


### PR DESCRIPTION
## Summary
This change integrates Renovate as an automated dependency management tool into the GitLab CI/CD pipeline, configured to run on a schedule while preventing it from interfering with regular lint and test jobs.

## Key Changes
- Added `renovate` stage to the CI/CD pipeline stages
- Created a new `renovate` job that:
  - Uses the official `renovate/renovate:latest` Docker image
  - Configures Renovate to work with GitLab API
  - Sets up automatic discovery disabled with explicit repository targeting
  - Configures a bot Git author for commits
  - Runs only on scheduled pipelines (with `RENOVATE=true` variable) or manual web triggers
- Updated `lint` and `test` jobs with rules to skip execution during Renovate scheduled runs, preventing unnecessary job duplication
- Updated CI/CD file header comment to document the new Renovate scheduled pipeline capability

## Implementation Details
- Renovate is triggered via GitLab scheduled pipelines with the `RENOVATE=true` variable
- Requires a `RENOVATE_TOKEN` CI/CD variable (GitLab PAT with `api` scope, marked as masked and protected)
- Can also be manually triggered via "Run pipeline" with the `RENOVATE=true` variable
- The job uses an empty entrypoint to allow the Renovate container's default entrypoint to execute
- Log level set to `info` for visibility into Renovate's operations

https://claude.ai/code/session_01JYn2NZ6bJ8qE1Re1vg5zkJ